### PR TITLE
Fix: Enable chatbot and update stylesheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -1655,7 +1655,7 @@ ${name}
 
             try {
                 const payload = { contents: historyArray };
-                const apiKey = ""; // Canvas will provide this at runtime
+                const apiKey = "AIzaSyDDRKp0fJPt2fNF2GEq_cYWWVdijUTUJDE"; // Canvas will provide this at runtime
                 const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`;
 
                 const response = await fetch(apiUrl, {
@@ -1705,6 +1705,6 @@ ${name}
             return messageElement; // Return the created element for potential removal (e.g., loading message)
         }
     </script>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" xintegrity="sha512-Fo3rlrZj/k7ujTnHg4CGR2D7kSs0xXgJb/0j+68/N81L/b/f/2t/m1z412/123456789012345678901234567890123456789012345678901234567890" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.0/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
 </body>
 </html>


### PR DESCRIPTION
This change enables the AI chatbots by adding the user-provided Google Gemini API key. It also fixes a broken Font Awesome stylesheet link by updating it to a newer, working version. This should make the chatbots functional and ensure that all icons on the page render correctly.